### PR TITLE
Allow empty/null keys when rendering message.

### DIFF
--- a/src/main/resources/templates/message-inspector.ftl
+++ b/src/main/resources/templates/message-inspector.ftl
@@ -59,7 +59,7 @@
         <#assign offset=messageForm.offset + msg_index>
         <div data-offset="${offset}" class="message-detail">
             <span class="bs-label">Offset:</span> ${offset}
-            <span class="bs-label">Key:</span> ${msg.key}
+            <span class="bs-label">Key:</span> ${(msg.key)!''}
             <span class="bs-label">Checksum/Computed:</span> <span <#if !msg.valid>class="error"</#if>>${msg.checksum}/${msg.computedChecksum}</span>
             <span class="bs-label">Compression:</span> ${msg.compressionCodec}
             <div>


### PR DESCRIPTION
Only smoke tested, but this seemed to be the only thing I needed to do for viewing messages in a 0.9.0.1 cluster.