### PR TITLE
Added docker support.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -138,6 +138,73 @@
             </configuration>
          </plugin>
          <plugin>
+            <artifactId>maven-assembly-plugin</artifactId>
+            <configuration>
+               <descriptors>
+                  <descriptor>src/main/assembly/bin.xml</descriptor>
+               </descriptors>
+            </configuration>
+            <version>2.2.1</version>
+         </plugin>
+         <plugin>
+            <!-- Build an executable JAR -->
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-jar-plugin</artifactId>
+            <version>2.4</version>
+            <configuration>
+               <archive>
+                  <manifest>
+                     <addClasspath>true</addClasspath>
+                     <classpathPrefix>lib/</classpathPrefix>
+                     <mainClass>com.homeadvisor.kafdrop.KafDrop</mainClass>
+                  </manifest>
+               </archive>
+            </configuration>
+         </plugin>
+         <plugin>
+            <groupId>com.spotify</groupId>
+            <artifactId>docker-maven-plugin</artifactId>
+            <version>0.4.9</version>
+            <configuration>
+               <imageName>kafdrop</imageName>
+               <forceTags>true</forceTags>
+               <dockerDirectory>${project.build.directory}/docker-ready</dockerDirectory>
+               <imageTags>
+                  <imageTag>${project.version}</imageTag>
+                  <imageTag>latest</imageTag>
+               </imageTags>
+               <resources>
+                  <resource>
+                     <targetPath>/</targetPath>
+                     <directory>${project.build.directory}</directory>
+                     <include>${project.build.finalName}-bin.tar.gz</include>
+                  </resource>
+               </resources>
+            </configuration>
+         </plugin>
+         <plugin>
+            <artifactId>maven-resources-plugin</artifactId>
+            <version>2.7</version>
+            <executions>
+               <execution>
+                  <id>prepare-dockerfile</id>
+                  <phase>validate</phase>
+                  <goals>
+                     <goal>copy-resources</goal>
+                  </goals>
+                  <configuration>
+                     <outputDirectory>${project.build.directory}/docker-ready</outputDirectory>
+                     <resources>
+                        <resource>
+                           <directory>src/main/docker</directory>
+                           <filtering>true</filtering>
+                        </resource>
+                     </resources>
+                  </configuration>
+               </execution>
+            </executions>
+         </plugin>
+         <plugin>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-maven-plugin</artifactId>
             <version>${spring.boot.version}</version>

--- a/src/main/assembly/bin.xml
+++ b/src/main/assembly/bin.xml
@@ -1,0 +1,39 @@
+<assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3" 
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 http://maven.apache.org/xsd/assembly-1.1.3.xsd">
+  <id>bin</id>
+  <formats>
+    <format>tar.gz</format>
+    <format>zip</format>
+  </formats>
+  <dependencySets>
+      
+    <dependencySet>
+        <scope>runtime</scope>
+        <useTransitiveDependencies>true</useTransitiveDependencies>
+        <outputDirectory>lib</outputDirectory>
+    </dependencySet>
+  </dependencySets>
+  <fileSets>
+    <fileSet>
+      <directory>${project.basedir}</directory>
+      <outputDirectory>/</outputDirectory>
+      <includes>
+        <include>README*</include>
+        <include>LICENSE*</include>
+        <include>NOTICE*</include>
+      </includes>
+    </fileSet>
+    <fileSet>
+      <directory>${project.build.directory}</directory>
+      <outputDirectory>/</outputDirectory>
+      <includes>
+        <include>*.jar</include>
+      </includes>
+    </fileSet>
+    <fileSet>
+      <directory>${project.build.directory}/site</directory>
+      <outputDirectory>docs</outputDirectory>
+    </fileSet>
+  </fileSets>
+</assembly>

--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -1,0 +1,9 @@
+FROM java:8
+MAINTAINER homeadvisor
+
+ADD kafdrop.sh /
+ADD kafdrop*tar.gz /
+
+RUN chmod +x /kafdrop.sh
+
+ENTRYPOINT ["/kafdrop.sh"]

--- a/src/main/docker/kafdrop.sh
+++ b/src/main/docker/kafdrop.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# Set marathon ports to 0:0 to have marathon assign and pass random port
+if [ $PORT0 ]; then
+    JMX_PORT=$PORT0;
+fi
+
+# Marathon passes "HOST" variable
+if [ -z $HOST ]; then
+    HOST=localhost;
+fi
+
+# Marathon passes memory limit
+if [ $MARATHON_APP_RESOURCE_MEM ]; then
+    HEAP_ARGS="-Xms${MARATHON_APP_RESOURCE_MEM%.*}m -Xmx${MARATHON_APP_RESOURCE_MEM%.*}m"
+fi
+
+if [ $JMX_PORT ]; then
+    JMX_ARGS="-Dcom.sun.management.jmxremote \
+    -Dcom.sun.management.jmxremote.port=${JMX_PORT} \
+    -Dcom.sun.management.jmxremote.rmi.port=${JMX_PORT} \
+    -Dcom.sun.management.jmxremote.local.only=false \
+    -Dcom.sun.management.jmxremote.authenticate=false \
+    -Dcom.sun.management.jmxremote.ssl=false \
+    -Djava.rmi.server.hostname=$HOST"
+fi
+
+java $JMX_ARGS $HEAP_ARGS -jar /kafdrop*/kafdrop*jar
+


### PR DESCRIPTION
I plan on using Kafdrop for a project I'm working, and I needed it dockerized. Figured I'd commit this back since I saw an open issue. Feel free to review, accept, reject, etc.

Uses maven-assembly to build the tar, then spotify docker-maven-plugin to build/push the docker image. I have not pushed it anywhere, as I do not have any experience pushing to dockerhub.

I built with 
`mvn clean package assembly:single docker:build`

I ran with 
`docker run -d -p 9000:9000 -e ZOOKEEPER_CONNECT=master.mesos:2181/kafka kafdrop`

When running in marathon, the memory constraint will automatically trigger JVM heap args to get set. Also, JMX should still be accessible, but you'll need to look at the randomly assigned port.

