### PR TITLE
JDK11 workaround

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -133,6 +133,11 @@
          <groupId>org.springframework.boot</groupId>
          <artifactId>spring-boot-starter-actuator</artifactId>
       </dependency>
+      <dependency>
+        <groupId>javax.xml.bind</groupId>
+        <artifactId>jaxb-api</artifactId>
+        <version>1.0.6</version>
+      </dependency>
 
       <!-- Spring -->
       <dependency>

--- a/src/main/java/com/homeadvisor/kafdrop/config/ServiceDiscoveryConfiguration.java
+++ b/src/main/java/com/homeadvisor/kafdrop/config/ServiceDiscoveryConfiguration.java
@@ -48,7 +48,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 @Configuration
-@ConditionalOnProperty("curator.discovery.enabled")
+@ConditionalOnProperty(value = "curator.discovery.enabled", havingValue = "true")
 public class ServiceDiscoveryConfiguration
 {
    @Autowired


### PR DESCRIPTION
With these two commits it does not yet compile with jdk11. But it can be compiled with jdk8 and then the jar can be executed successfully with
`java -jar kafdrop.jar --curator.discovery.enabled=false`